### PR TITLE
Enable hardware acceleration for Plex

### DIFF
--- a/nas/plex/docker-compose.yaml
+++ b/nas/plex/docker-compose.yaml
@@ -12,6 +12,8 @@ services:
       - "32413:32413/udp"
       - "32414:32414/udp"
       - "32469:32469"
+    devices:
+      - /dev/dri:/dev/dri
     environment:
       PUID: 1000
       PGID: 10


### PR DESCRIPTION
## Summary
- Add `/dev/dri` device passthrough to Plex container to enable hardware acceleration for video transcoding

## Why
Hardware acceleration significantly reduces CPU usage and improves transcoding performance by offloading work to the GPU.

## Test plan
- [ ] Verify Plex container starts successfully with device passthrough
- [ ] Check Plex transcoder settings show hardware acceleration available
- [ ] Test video transcoding and verify GPU is being used

🤖 Generated with [Claude Code](https://claude.com/claude-code)